### PR TITLE
feat: [qa-578] export job-level metrics for GH Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Authentication can either via a Github Token or the Github App Authentication 3 
 | Github Api URL | github_api_url, url | GITHUB_API_URL | api.github.com | Github API URL (primarily for Github Enterprise usage) |
 | Github Enterprise Name | enterprise_name | ENTERPRISE_NAME | "" | Enterprise name. Needed for enterprise endpoints (/enterprises/{ENTERPRISE_NAME}/*). Currently used to get Enterprise level tunners status |
 | Fields to export | export_fields | EXPORT_FIELDS | repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status | A comma separated list of fields for workflow metrics that should be exported |
+| Export job fields | export_job_fields | EXPORT_JOB_FIELDS | repo,workflow,job_name,conclusion,event | A comma-separated list of fields for job-level metrics that should be exported |
 
 ## Exported stats
 
@@ -93,6 +94,48 @@ Gauge type
 | workflow_id | Workflow ID |
 | workflow | Workflow Name |
 | status | Workflow status (completed/in_progress) |
+
+### github_workflow_job_status
+Gauge type
+
+**Result possibility**
+
+| ID | Description |
+|---|---|
+| 0 | Failure |
+| 1 | Success |
+| 2 | Skipped |
+| 3 | In Progress |
+| 4 | Queued |
+
+**Fields**
+
+| Name | Description |
+|---|---|
+| repo | Repository like \<org>/\<repo> |
+| workflow | Workflow Name |
+| job_name | Name of the job |
+| conclusion | Job conclusion (success/failure/skipped/cancelled) |
+| event | Event type like push/pull_request/... |
+
+### github_workflow_job_duration_seconds
+Gauge type
+
+**Result possibility**
+
+| Gauge | Description |
+|---|---|
+| seconds | Number of seconds that a specific workflow job took time to complete. |
+
+**Fields**
+
+| Name | Description |
+|---|---|
+| repo | Repository like \<org>/\<repo> |
+| workflow | Workflow Name |
+| job_name | Name of the job |
+| conclusion | Job conclusion (success/failure/skipped/cancelled) |
+| event | Event type like push/pull_request/... |
 
 ### github_job
 > :warning: **This is a duplicate of the `github_workflow_run_status` metric that will soon be deprecated, do not use anymore.**

--- a/charts/github-actions-exporter/values.yaml
+++ b/charts/github-actions-exporter/values.yaml
@@ -16,6 +16,7 @@ env:
   GITHUB_API_URL: api.github.com
 #  ENTERPRISE_NAME: "" # Needed for enterprise endpoints (/enterprises/{ENTERPRISE_NAME}/*)
 #  EXPORT_FIELDS: "repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status"  # A comma separated list of fields for workflow metrics that should be exported
+#  EXPORT_JOB_FIELDS: "repo,workflow,job_name,conclusion,event"  # A comma separated list of fields for job metrics that should be exported
 #  For the github authentications need to create a secret by default called actions-exporter
 #  for authentication via github personal token
 #                key: github_token

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ var (
 	Debug          bool
 	EnterpriseName string
 	WorkflowFields string
+	WorkflowJobFields string
 )
 
 // InitConfiguration - set configuration from env vars or command parameters
@@ -112,6 +113,13 @@ func InitConfiguration() []cli.Flag {
 			Usage:       "A comma separated list of fields for workflow metrics that should be exported",
 			Value:       "repo,id,node_id,head_branch,head_sha,run_number,workflow_id,workflow,event,status",
 			Destination: &WorkflowFields,
+		},
+		&cli.StringFlag{
+			Name:        "export_job_fields",
+			EnvVars:     []string{"EXPORT_JOB_FIELDS"},
+			Usage:       "A comma separated list of fields for job metrics that should be exported",
+			Value:       "repo,workflow,job_name,conclusion,event",
+			Destination: &WorkflowJobFields,
 		},
 		&cli.BoolFlag{
 			Name:        "fetch_workflow_run_usage",

--- a/pkg/metrics/get_workflow_jobs_from_github.go
+++ b/pkg/metrics/get_workflow_jobs_from_github.go
@@ -1,0 +1,112 @@
+package metrics
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/spendesk/github-actions-exporter/pkg/config"
+)
+
+// getJobFieldValue - returns a value for a given field from a GitHub workflow job
+func getJobFieldValue(repo string, workflow string, event string, job *github.WorkflowJob, field string) string {
+	switch field {
+	case "repo":
+		return repo
+	case "workflow":
+		return workflow
+	case "job_name":
+		return job.GetName()
+	case "conclusion":
+		return job.GetConclusion()
+	case "event":
+		return event
+	}
+	log.Printf("Tried to fetch invalid job field '%s'", field)
+	return ""
+}
+
+func getRelevantJobFields(repo string, workflow string, event string, job *github.WorkflowJob) []string {
+	relevantFields := strings.Split(config.WorkflowJobFields, ",")
+	result := make([]string, len(relevantFields))
+	for i, field := range relevantFields {
+		result[i] = getJobFieldValue(repo, workflow, event,job, field)
+	}
+	return result
+}
+
+func getJobsForRun(owner string, repo string, runID int64) []*github.WorkflowJob {
+	opt := &github.ListWorkflowJobsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	var jobs []*github.WorkflowJob
+	for {
+		resp, rr, err := client.Actions.ListWorkflowJobs(context.Background(), owner, repo, runID, opt)
+		if rl_err, ok := err.(*github.RateLimitError); ok {
+			log.Printf("ListWorkflowJobs ratelimited. Pausing until %s", rl_err.Rate.Reset.Time.String())
+			time.Sleep(time.Until(rl_err.Rate.Reset.Time))
+			continue
+		} else if err != nil {
+			log.Printf("ListWorkflowJobs error for run %d in repo %s/%s: %s", runID, owner, repo, err.Error())
+			return jobs
+		}
+		jobs = append(jobs, resp.Jobs...)
+		if rr.NextPage == 0 {
+			break
+		}
+		opt.Page = rr.NextPage
+	}
+	return jobs
+}
+
+// getWorkflowJobsFromGithub - fetch jobs for each workflow run and emit metrics
+func getWorkflowJobsFromGithub() {
+	for {
+		for _, repo := range repositories {
+			r := strings.Split(repo, "/")
+			runs := getRecentWorkflowRuns(r[0], r[1])
+
+			// Create a map of run IDs to their events
+			runEventMap := make(map[int64]string)
+			for _, run := range runs {
+    			runEventMap[run.GetID()] = run.GetEvent()
+			}
+
+			for _, run := range runs {
+				event := runEventMap[run.GetID()] 
+				workflowName := getFieldValue(repo, *run, "workflow")
+				jobs := getJobsForRun(r[0], r[1], run.GetID())
+
+				for _, job := range jobs {
+					fields := getRelevantJobFields(repo, workflowName, event, job)
+
+					var status float64 = 0
+					switch job.GetConclusion() {
+					case "success":
+						status = 1
+					case "skipped":
+						status = 2
+					case "in_progress":
+						status = 3
+					case "queued":
+						status = 4
+					}
+					workflowJobStatusGauge.WithLabelValues(fields...).Set(status)
+
+					start := job.GetStartedAt()
+					end := job.GetCompletedAt()
+					
+					if !start.IsZero() && !end.IsZero() {
+						duration := end.Time.Sub(start.Time).Seconds()
+						workflowJobDurationGauge.WithLabelValues(fields...).Set(duration)
+					} else {
+						log.Printf("Skipping duration metric for job %s in run %d (start or end time missing)", job.GetName(), job.GetRunID())
+					}					
+				}
+			}
+		}
+		time.Sleep(time.Duration(config.Github.Refresh) * time.Second)
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,6 +23,8 @@ var (
 	err                      error
 	workflowRunStatusGauge   *prometheus.GaugeVec
 	workflowRunDurationGauge *prometheus.GaugeVec
+	workflowJobStatusGauge   *prometheus.GaugeVec
+	workflowJobDurationGauge *prometheus.GaugeVec
 )
 
 // InitMetrics - register metrics in prometheus lib and start func for monitor
@@ -41,10 +43,26 @@ func InitMetrics() {
 		},
 		strings.Split(config.WorkflowFields, ","),
 	)
+	workflowJobStatusGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_workflow_job_status",
+			Help: "Status of each job inside GitHub workflow run",
+		},
+		strings.Split(config.WorkflowJobFields, ","),
+	)
+	workflowJobDurationGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_workflow_job_duration_seconds",
+			Help: "Duration of each GitHub workflow job in seconds",
+		},
+		strings.Split(config.WorkflowJobFields, ","),
+	)
 	prometheus.MustRegister(runnersGauge)
 	prometheus.MustRegister(runnersOrganizationGauge)
 	prometheus.MustRegister(workflowRunStatusGauge)
 	prometheus.MustRegister(workflowRunDurationGauge)
+	prometheus.MustRegister(workflowJobStatusGauge)
+	prometheus.MustRegister(workflowJobDurationGauge)
 	prometheus.MustRegister(workflowBillGauge)
 	prometheus.MustRegister(runnersEnterpriseGauge)
 
@@ -65,6 +83,7 @@ func InitMetrics() {
 	go getRunnersFromGithub()
 	go getRunnersOrganizationFromGithub()
 	go getWorkflowRunsFromGithub()
+	go getWorkflowJobsFromGithub()
 	go getRunnersEnterpriseFromGithub()
 }
 


### PR DESCRIPTION
This PR adds support for monitoring individual jobs within GitHub Actions workflow runs, providing more granular visibility into workflow execution. It introduces new metrics to track job status and duration, along with configuration options to customize the exported fields.

### New Metrics
- Added `github_workflow_job_status`: Gauge metric showing job status
  - Values: Failure (0), Success (1), Skipped (2), In Progress (3), Queued (4)
  - Fields: repo, workflow, job_name, conclusion, event

- Added `github_workflow_job_duration_seconds`: Gauge metric showing job duration
  - Measures execution time in seconds for completed jobs
  - Same fields as job status metric

### Configuration
- Added new configuration option `export_job_fields` to specify which job-level fields should be exported
- Default value: `repo,workflow,job_name,conclusion,event`
- Added to Helm chart configuration in `values.yaml`
