### PR TITLE
add more values to metrics [qa-602]

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,7 +118,7 @@ func InitConfiguration() []cli.Flag {
 			Name:        "export_job_fields",
 			EnvVars:     []string{"EXPORT_JOB_FIELDS"},
 			Usage:       "A comma separated list of fields for job metrics that should be exported",
-			Value:       "repo,workflow,job_name,conclusion,event",
+			Value:       "repo,workflow,job_name,conclusion,event,run_id,job_id",
 			Destination: &WorkflowJobFields,
 		},
 		&cli.BoolFlag{

--- a/pkg/metrics/get_workflow_jobs_from_github.go
+++ b/pkg/metrics/get_workflow_jobs_from_github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"strings"
+	"strconv"
 	"time"
 
 	"github.com/google/go-github/v45/github"
@@ -23,6 +24,10 @@ func getJobFieldValue(repo string, workflow string, event string, job *github.Wo
 		return job.GetConclusion()
 	case "event":
 		return event
+	case "run_id":
+		return strconv.FormatInt(job.GetRunID(), 10)
+	case "job_id":
+		return strconv.FormatInt(job.GetID(), 10)
 	}
 	log.Printf("Tried to fetch invalid job field '%s'", field)
 	return ""


### PR DESCRIPTION
Add unique identifiers (run_id, job_id) into job metrics to prevent metric overwriting and enable accurate job tracking